### PR TITLE
[Test] 테스트용 Docker-DB 설정 및 프로파일 분리, 회원가입 기능 테스트 (#11)

### DIFF
--- a/auth-server/docker-compose.yml
+++ b/auth-server/docker-compose.yml
@@ -12,7 +12,22 @@ services:
       MARIADB_ROOT_PASSWORD: ${DB_PASSWORD}
     volumes:
       - mariadb-vl:/var/lib/mariadb
+  
+  # 테스트용
+  mariadb-test:
+    image: mariadb:latest
+    container_name: gold-auth-mariadb-test
+    ports:
+      - ${DB_TEST_PORT}:${DB_PORT}
+    restart: always
+    environment:
+      MARIADB_DATABASE: ${DB_NAME}_test
+      MARIADB_ROOT_PASSWORD: ${DB_PASSWORD}
+    volumes:
+      - mariadb-test-vl:/var/lib/mariadb
 
 volumes:
   mariadb-vl:
+    driver: local
+  mariadb-test-vl:
     driver: local

--- a/auth-server/src/main/java/com/ryuneng/goldauth/domain/user/controller/UserController.java
+++ b/auth-server/src/main/java/com/ryuneng/goldauth/domain/user/controller/UserController.java
@@ -6,6 +6,8 @@ import com.ryuneng.goldauth.domain.user.service.UserService;
 import com.ryuneng.goldauth.global.exception.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
@@ -16,9 +18,10 @@ public class UserController {
     private final UserService userService;
 
     @PostMapping()
-    public SuccessResponse<UserCreateResponse> signup(@Valid @RequestBody UserCreateRequest request) {
+    public ResponseEntity<SuccessResponse<UserCreateResponse>> signup(@Valid @RequestBody UserCreateRequest request) {
 
-        return SuccessResponse.created("회원가입이 완료되었습니다.", userService.signup(request));
+        SuccessResponse<UserCreateResponse> response = SuccessResponse.ok("회원가입이 완료되었습니다.", userService.signup(request));
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
 }

--- a/auth-server/src/main/java/com/ryuneng/goldauth/domain/user/dto/UserCreateRequest.java
+++ b/auth-server/src/main/java/com/ryuneng/goldauth/domain/user/dto/UserCreateRequest.java
@@ -28,7 +28,7 @@ public class UserCreateRequest {
     private String password;
 
     @NotBlank(message = "전화번호를 입력해주세요.")
-    @Pattern(regexp = "^01[0-9]\\d{3,4}\\d{4}$", message = "하이픈(-)을 제외한 숫자만 입력해주세요. (예: 01012345678)")
+    @Pattern(regexp = "^01[0-9]\\d{3,4}\\d{4}$", message = "전화번호는 하이픈(-)을 제외한 숫자만 입력해주세요. (예: 01012345678)")
     @Size()
     private String phoneNumber;
 

--- a/auth-server/src/main/java/com/ryuneng/goldauth/global/exception/response/SuccessResponse.java
+++ b/auth-server/src/main/java/com/ryuneng/goldauth/global/exception/response/SuccessResponse.java
@@ -1,16 +1,15 @@
 package com.ryuneng.goldauth.global.exception.response;
 
 import lombok.Getter;
-import org.springframework.http.HttpStatus;
 
 @Getter
 public class SuccessResponse<T> {
 
-    private HttpStatus success;
+    private boolean success;
     private String message;
     private T data;
 
-    public SuccessResponse(HttpStatus success, String message, T data) {
+    public SuccessResponse(boolean success, String message, T data) {
 
         this.success = success;
         this.message = message;
@@ -19,12 +18,7 @@ public class SuccessResponse<T> {
 
     public static <T> SuccessResponse<T> ok(String message, T data) {
 
-        return new SuccessResponse<>(HttpStatus.OK, message, data);
-    }
-
-    public static <T> SuccessResponse<T> created(String message, T data) {
-
-        return new SuccessResponse<>(HttpStatus.CREATED, message, data);
+        return new SuccessResponse<>(true, message, data);
     }
 
 }

--- a/auth-server/src/main/resources/application.yml
+++ b/auth-server/src/main/resources/application.yml
@@ -1,7 +1,11 @@
+# 1. 기본값 프로파일
 server:
   port: ${SERVER_PORT}
 
 spring:
+  profiles:
+    default: local # (로컬로 지정)
+
   application:
     name: auth-server
 
@@ -18,7 +22,7 @@ spring:
   jpa:
     open-in-view: true
     hibernate:
-      ddl-auto: create # 서버 실행 시 DB의 모든 테이블 삭제 후 재생성
+      ddl-auto: none
       naming:
         use-new-id-generator-mappings: false
     show-sql: true
@@ -28,4 +32,48 @@ spring:
           new_generator_mappings: true
         format_sql: true
       dialect: org.hibernate.dialect.MariaDBDialect
+
+# 2. 로컬용 프로파일 (보통 배포 전 초기 개발 단계에 사용)
+---
+spring:
+  config:
+    activate:
+      on-profile: local # 프로파일명
+
+  jpa:
+    hibernate:
+      ddl-auto: update # 서버 재실행 시 기존 DB 데이터 유지 (첫 실행 시에만 create 설정 필요)
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
     defer-datasource-initialization: true # (2.5~) Hibernate 초기화 이후 data.sql 실행
+
+  sql:
+    init:
+      mode: never # 서버 실행 시 data.sql 파일 항상 실행하지 않음 (첫 실행 시에만 always 설정 필요)
+
+# 3. 테스트 실행 전용 프로파일
+---
+spring:
+  config:
+    activate:
+      on-profile: test # 프로파일명 (@ActiveProfiles("test") 어노테이션을 부착한 테스트 클래스만 테스트 환경으로 실행)
+
+  datasource:
+    url: jdbc:mariadb://${DB_HOST}:${DB_TEST_PORT}:${DB_PORT}/${DB_NAME}_test
+    username: ${DB_USER}
+    password: ${DB_PASSWORD}
+    driver-class-name: org.mariadb.jdbc.Driver
+
+  jpa:
+    hibernate:
+      ddl-auto: create # 테스트 실행 시 DB의 모든 테이블 삭제 후 재생성
+    show-sql: true
+    properties:
+      hibernate:
+        format_sql: true
+
+  sql:
+    init:
+      mode: never # 테스트 실행 시 data.sql 파일 실행하지 않음

--- a/auth-server/src/main/resources/application.yml
+++ b/auth-server/src/main/resources/application.yml
@@ -42,7 +42,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update # 서버 재실행 시 기존 DB 데이터 유지 (첫 실행 시에만 create 설정 필요)
+      ddl-auto: create # 서버 실행 시 DB의 모든 테이블 삭제 후 재생성
     show-sql: true
     properties:
       hibernate:
@@ -51,7 +51,7 @@ spring:
 
   sql:
     init:
-      mode: never # 서버 실행 시 data.sql 파일 항상 실행하지 않음 (첫 실행 시에만 always 설정 필요)
+      mode: always # 서버 실행 시 data.sql 파일 항상 실행
 
 # 3. 테스트 실행 전용 프로파일
 ---

--- a/auth-server/src/main/resources/data.sql
+++ b/auth-server/src/main/resources/data.sql
@@ -1,0 +1,5 @@
+INSERT INTO user
+    (id, username, password, phone_number, role, created_at, updated_at, deleted_yn)
+VALUES
+    (1, 'admin', 'admin1234', '01011223344', 'ADMIN', '2024-09-08 12:00:00', '2024-09-08 12:00:00', 'N'),
+    (2, 'user1', 'user1234', '01055667788', 'USER', '2024-09-08 12:00:00', '2024-09-08 12:00:00', 'N');

--- a/auth-server/src/test/java/com/ryuneng/goldauth/domain/user/controller/UserControllerTest.java
+++ b/auth-server/src/test/java/com/ryuneng/goldauth/domain/user/controller/UserControllerTest.java
@@ -1,0 +1,62 @@
+package com.ryuneng.goldauth.domain.user.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ryuneng.goldauth.domain.user.dto.UserCreateRequest;
+import com.ryuneng.goldauth.domain.user.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+@AutoConfigureMockMvc(addFilters = false) // Spring Security 필터 비활성화
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private UserService userService;
+
+    @DisplayName("신규 유저를 등록(회원가입)한다.")
+    @Test
+    void signup() throws Exception {
+        // given
+        UserCreateRequest request = createUserCreateRequestBuilder("user1", "test1234", "01012345678");
+
+        // when // then
+        mockMvc.perform(
+                        post("/api/users")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.message").value("회원가입이 완료되었습니다."));
+    }
+
+    // 유저 Request DTO 빌더 생성
+    private UserCreateRequest createUserCreateRequestBuilder(String username, String password, String phoneNumber) {
+
+        return UserCreateRequest.builder()
+                .username(username)
+                .password(password)
+                .phoneNumber(phoneNumber)
+                .build();
+    }
+
+}

--- a/auth-server/src/test/java/com/ryuneng/goldauth/domain/user/controller/UserControllerTest.java
+++ b/auth-server/src/test/java/com/ryuneng/goldauth/domain/user/controller/UserControllerTest.java
@@ -49,6 +49,96 @@ class UserControllerTest {
                 .andExpect(jsonPath("$.message").value("회원가입이 완료되었습니다."));
     }
 
+    @DisplayName("유효 범위를 벗어난 길이의 아이디로 회원가입을 시도한다.")
+    @Test
+    void signupWithWrongLengthUsername() throws Exception {
+        // given
+        UserCreateRequest request = createUserCreateRequestBuilder("u", "test1234", "01012345678");
+
+        // when // then
+        mockMvc.perform(
+                        post("/api/users")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("아이디는 5자에서 20자 사이여야 합니다."));
+    }
+
+    @DisplayName("형식에 맞지 않는 아이디로 회원가입을 시도한다.")
+    @Test
+    void signupWithWrongUsername() throws Exception {
+        // given
+        UserCreateRequest request = createUserCreateRequestBuilder("User!", "test1234", "01012345678");
+
+        // when // then
+        mockMvc.perform(
+                        post("/api/users")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("아이디는 영문 소문자, 숫자, 특수기호(-, _)만 사용 가능합니다."));
+    }
+
+    @DisplayName("유효 범위를 벗어난 길이의 비밀번호로 회원가입을 시도한다.")
+    @Test
+    void signupWithWrongLengthPassword() throws Exception {
+        // given
+        UserCreateRequest request = createUserCreateRequestBuilder("user1", "test", "01012345678");
+
+        // when // then
+        mockMvc.perform(
+                        post("/api/users")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("비밀번호는 8자에서 16자 사이여야 합니다."));
+    }
+
+    @DisplayName("형식에 맞지 않는 비밀번호로 회원가입을 시도한다.")
+    @Test
+    void signupWithWrongPassword() throws Exception {
+        // given
+        UserCreateRequest request = createUserCreateRequestBuilder("user1", "testtest", "01012345678");
+
+        // when // then
+        mockMvc.perform(
+                        post("/api/users")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("비밀번호는 영문 대/소문자, 숫자, 특수문자 중 2가지 이상을 포함해야 합니다."));
+    }
+
+    @DisplayName("형식에 맞지 않는 전화번호로 회원가입을 시도한다.")
+    @Test
+    void signupWithWrongPhoneNumber() throws Exception {
+        // given
+        UserCreateRequest request = createUserCreateRequestBuilder("user1", "test1234", "010-1234-5678");
+
+        // when // then
+        mockMvc.perform(
+                        post("/api/users")
+                                .content(objectMapper.writeValueAsString(request))
+                                .contentType(MediaType.APPLICATION_JSON)
+                )
+                .andDo(print())
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.success").value(false))
+                .andExpect(jsonPath("$.message").value("전화번호는 하이픈(-)을 제외한 숫자만 입력해주세요. (예: 01012345678)"));
+    }
+
     // 유저 Request DTO 빌더 생성
     private UserCreateRequest createUserCreateRequestBuilder(String username, String password, String phoneNumber) {
 

--- a/auth-server/src/test/java/com/ryuneng/goldauth/domain/user/repository/UserRepositoryTest.java
+++ b/auth-server/src/test/java/com/ryuneng/goldauth/domain/user/repository/UserRepositoryTest.java
@@ -1,0 +1,64 @@
+package com.ryuneng.goldauth.domain.user.repository;
+
+import com.ryuneng.goldauth.domain.user.entity.User;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+
+import static com.ryuneng.goldauth.domain.user.enums.Role.USER;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class UserRepositoryTest {
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("유저 아이디로 유저를 조회한다.")
+    @Test
+    void findUserByUsername() {
+        // given
+        User user = userRepository.save(createUserBuilder());
+
+        // when
+        userRepository.findByUsername(user.getUsername());
+
+        // then
+        assertThat(user)
+                .extracting("id", "username", "password", "phoneNumber", "role")
+                .contains(1L, "username", "user1234", "01012345678", USER);
+    }
+
+    @DisplayName("존재하지 않는 유저 아이디로 유저를 조회한다.")
+    @Test
+    void findUserByWithNonExistentUsername() {
+        // given
+        String username = "username";
+
+        // when // then
+        assertThat(userRepository.findByUsername(username)).isEmpty();
+    }
+
+    // 유저 빌더 생성
+    private static User createUserBuilder() {
+
+        return User.builder()
+                .id(1L)
+                .username("username")
+                .password("user1234")
+                .phoneNumber("01012345678")
+                .role(USER)
+                .build();
+    }
+
+}

--- a/auth-server/src/test/java/com/ryuneng/goldauth/domain/user/service/UserServiceTest.java
+++ b/auth-server/src/test/java/com/ryuneng/goldauth/domain/user/service/UserServiceTest.java
@@ -1,0 +1,59 @@
+package com.ryuneng.goldauth.domain.user.service;
+
+import com.ryuneng.goldauth.domain.user.dto.UserCreateRequest;
+import com.ryuneng.goldauth.domain.user.dto.UserCreateResponse;
+import com.ryuneng.goldauth.domain.user.repository.UserRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.context.ActiveProfiles;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@ActiveProfiles("test")
+@SpringBootTest
+class UserServiceTest {
+
+    @Autowired
+    private UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @Autowired
+    private PasswordEncoder passwordEncoder;
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAllInBatch();
+    }
+
+    @DisplayName("신규 유저를 등록(회원가입)한다.")
+    @Test
+    void signup() {
+        // given
+        UserCreateRequest request = createUserCreateRequestBuilder();
+
+        // when
+        UserCreateResponse response = userService.signup(request);
+
+        // then
+        assertThat(response)
+                .extracting("username")
+                .isEqualTo(response.getUsername());
+    }
+
+    // 유저 Request DTO 빌더 생성
+    private UserCreateRequest createUserCreateRequestBuilder() {
+
+        return UserCreateRequest.builder()
+                .username("user1")
+                .password(passwordEncoder.encode("test1234"))
+                .phoneNumber("01012345678")
+                .build();
+    }
+
+}

--- a/auth-server/src/test/java/com/ryuneng/goldauth/domain/user/service/UserServiceTest.java
+++ b/auth-server/src/test/java/com/ryuneng/goldauth/domain/user/service/UserServiceTest.java
@@ -3,6 +3,8 @@ package com.ryuneng.goldauth.domain.user.service;
 import com.ryuneng.goldauth.domain.user.dto.UserCreateRequest;
 import com.ryuneng.goldauth.domain.user.dto.UserCreateResponse;
 import com.ryuneng.goldauth.domain.user.repository.UserRepository;
+import com.ryuneng.goldauth.global.exception.CustomException;
+import com.ryuneng.goldauth.global.exception.ErrorCode;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -12,6 +14,7 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @ActiveProfiles("test")
 @SpringBootTest
@@ -44,6 +47,21 @@ class UserServiceTest {
         assertThat(response)
                 .extracting("username")
                 .isEqualTo(response.getUsername());
+    }
+
+    @DisplayName("이미 존재하는 아이디로 회원가입을 시도한다.")
+    @Test
+    void signupWithDuplicationUsername() {
+        // given
+        UserCreateRequest request = createUserCreateRequestBuilder();
+
+        // when
+        userService.signup(request);
+
+        // then
+        assertThatThrownBy(() -> userService.signup(request))
+                .isInstanceOf(CustomException.class)
+                .hasMessage(ErrorCode.USERNAME_DUPLICATION.getMessage());
     }
 
     // 유저 Request DTO 빌더 생성


### PR DESCRIPTION
## 📌 작업 내용
- 로컬과 테스트 전용 프로파일을 분리하였습니다.
- 테스트를 위한 Docker 기반 MariaDB를 설정하였습니다.
- 회원가입 기능의 Repository, Service, Controller 계층에 대해 해피케이스와 예외케이스를 테스트하였습니다.
- 인증 서버 더미데이터 파일을 생성하였습니다.

> 로컬과 테스트 전용 Docker DB
![스크린샷 2024-09-10 021126](https://github.com/user-attachments/assets/6ad20e54-c3e1-4c35-8cee-e28f93b16809)

> 테스트 결과
![image](https://github.com/user-attachments/assets/1cba447f-cd60-45a8-9f9b-1bf2e80512d8)
![image](https://github.com/user-attachments/assets/43468a5d-cffc-4ad4-991d-724caa72462e)
![image](https://github.com/user-attachments/assets/ff4f9193-23da-4499-9216-61e76053e778)

<br/>

## 🌱 반영 브랜치
- test/11-signup-test
- close #11 

<br/>

## 🔥 트러블 슈팅
### 1. 테스트용 DB 설정 및 프로파일 분리
#### 🤔 고민한 내용
  - 로컬 환경과 테스트 환경을 분리하면서, **테스트 시 로컬에서 사용하는 실제 DB와 동일한 데이터베이스를 사용할 것인지**에 대해 고민했다.

#### ❓ 고민한 이유
  - 로컬 DB와 테스트 DB를 동일하게 유지하면 편리할 수 있지만, **테스트 중 데이터가 손상되거나 의도하지 않은 영향**을 미칠까 우려되었다.

#### 💡 결론
  - **테스트 환경과 실제 로컬 개발 환경을 완전히 분리**하기로 결정했다.
  이를 위해 Docker를 활용해 테스트 전용 MariaDB를 설정하여 테스트 데이터와 로컬 데이터를 독립적으로 관리할 수 있게 했다.
  이로 인해 테스트 중 발생하는 데이터 변화가 로컬 DB에 영향을 주지 않고, 테스트 환경을 필요에 따라 쉽게 초기화하거나 재구성할 수 있어 더 **안전하고 효율적인 테스트 환경**을 구성할 수 있게 되었다.

<br>
<br>

### 2. POST 요청 성공 응답코드 `HttpStatus.OK` / `HttpStatus.CREATED` 반환
#### 🧐 문제
- `@PostMapping` 요청의 반환값으로 `SuccessResponse.created()`를 사용했는데,
  실제 응답은 **`201 CREATED`가 아닌 `200 OK`가 반환**되었다.
```java
// 작성한 코드
@PostMapping
public SuccessResponse<UserCreateResponse> signup(@Valid @RequestBody UserCreateRequest request) {
    return SuccessResponse.created("회원가입이 완료되었습니다.", userService.signup(request));
}
```
```java
// SuccessResponse 클래스
@Getter
public class SuccessResponse<T> {

    private HttpStatus success;
    private String message;
    private T data;

    public SuccessResponse(HttpStatus success, String message, T data) {

        this.success = success;
        this.message = message;
        this.data = data;
    }

    public static <T> SuccessResponse<T> ok(String message, T data) {

        return new SuccessResponse<>(HttpStatus.OK, message, data);
    }

    public static <T> SuccessResponse<T> created(String message, T data) {

        return new SuccessResponse<>(HttpStatus.CREATED, message, data);
    }
}
```
  
<br>

#### ❓ 원인
`SuccessResponse.created` 메서드가 `HttpStatus.CREATED`를 반환하도록 설정하더라도,
  Spring은 기본적으로 **`ResponseEntity`를 사용하지 않으면 HTTP 상태 코드를 자동으로 설정하지 않는다.**
  - Spring MVC는 컨트롤러 메서드에서 반환된 객체를 HTTP 응답 본문으로 직렬화하지만,
  상태 코드를 명시적으로 설정하지 않으면 기본값인 `HttpStatus.OK(200)`가 반환된다.
  - 즉, `SuccessResponse.created()`가 내부적으로 `HttpStatus.CREATED`를 설정하고 있어도, 이 정보는 **응답의 실제 HTTP 상태 코드에 반영되지 않는다.**

<br>

#### 💡 해결
  - 반환값을 **`ResponseEntity<>`로 감싸서 상태 코드를 명시적으로 설정**했다.
    수정 후, 실제로 `201 CREATED` 상태 코드가 반환되었다.
```java
@PostMapping
public ResponseEntity<SuccessResponse<UserCreateResponse>> signup(@Valid @RequestBody UserCreateRequest request) {
    SuccessResponse<UserCreateResponse> response = SuccessResponse.created("회원가입이 완료되었습니다.", userService.signup(request));
    return new ResponseEntity<>(response, HttpStatus.CREATED);
}
```
